### PR TITLE
Bug fix/193 csv file validation

### DIFF
--- a/bookbuddy/frontend/src/addBooksViaCSV.tsx
+++ b/bookbuddy/frontend/src/addBooksViaCSV.tsx
@@ -46,7 +46,8 @@ const CSVReader: React.FC = () => {
         .map((line) => line.trim())
         .filter((line) => line !== "");
 
-      if (lines.length === 0) return;
+      if (lines.length === 0 || lines[0] === undefined) return;
+
 
       const csvSplitRegExp = /,(?=(?:[^"]*"[^"]*")*[^"]*$)/;
 
@@ -54,8 +55,10 @@ const CSVReader: React.FC = () => {
       const headerCells = lines[0].split(csvSplitRegExp);
       let titleColIndex = -1;
 
+
+
       for (let i = 0; i < headerCells.length; i++) {
-        if (headerCells[i].replace(/"/g, "").trim().toLowerCase() === "title") {
+        if (headerCells[i]?.replace(/"/g, "").trim().toLowerCase() === "title") {
           titleColIndex = i;
           break;
         }


### PR DESCRIPTION
Fixes two small bugs with the CSV file uploader.

The main one is that you could upload any type of file by selecting the option in the browser.
Before: Random garbage from the header of the file would be used as the titles of the books
Now: The function is broken out of and an alert is shown the user. This may be updated in the future to text on the website, but for now this seems appropriate.

The other bug which was a pain to find that was caused by the google books search changing depending on if the query had quotes or not. For example: Harry Potter and "Harry Potter" in the search return different results!
Before: Sometimes seemingly random books would be added from the CSV file 
Now: The function removes quotation marks at the end of the processes (along with the already blocked '#' and '\')
