### PR TITLE
Finally removing the google books API key that was just making thing worse

### DIFF
--- a/bookbuddy/frontend/src/addBooksViaCSV.tsx
+++ b/bookbuddy/frontend/src/addBooksViaCSV.tsx
@@ -91,8 +91,8 @@ const CSVReader: React.FC = () => {
       // Skip header row
       titles = titles.slice(1);
 
-      // Limit to 25 books (plus header originally)
-      titles = titles.slice(0, 25);
+      // Limit to 25 books (no longer needed because no more API key)
+      //titles = titles.slice(0, 25);
 
       if (titles.length === 0) return;
 
@@ -208,8 +208,7 @@ const CSVReader: React.FC = () => {
                 color: "#B6D15C",
               }}
             >
-              For now, users are limited to 25 Books from their imported
-              library!
+                Larger files will lead to longer wait times!
             </div>
 
             <div

--- a/bookbuddy/src/main/java/com/example/bookbuddy/backend/web/googlebooksapi/GoogleBooksAPI.java
+++ b/bookbuddy/src/main/java/com/example/bookbuddy/backend/web/googlebooksapi/GoogleBooksAPI.java
@@ -39,7 +39,7 @@ public class GoogleBooksAPI {
     @GetMapping("/search")
     public ResponseEntity<?> search(@RequestParam("q") String query) {
         String encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8);
-        String fullUrl = BASE_URL + encoded + "&maxResults=30&orderBy=relevance&key=" + API_KEY;
+        String fullUrl = BASE_URL + encoded + "&maxResults=30&orderBy=relevance"; //&key=" + API_KEY;
 
         try {
             System.out.println("🔑 Google Books API URL: " + fullUrl);


### PR DESCRIPTION
Also removed the 25 book limit to using a CSV file (and its warning message)

Tested locally, deployed, and without the .env file